### PR TITLE
NGC-2463 Fix memory leak

### DIFF
--- a/src/main/scala/uk/gov/hmrc/msasync/filter/SessionCookieCryptoFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/msasync/filter/SessionCookieCryptoFilter.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.msasync.filter
 
-import akka.actor.ActorSystem
-import akka.stream.{Materializer, ActorMaterializer}
 import uk.gov.hmrc.crypto.{ApplicationCrypto, Crypted, PlainText}
 import uk.gov.hmrc.play.filters.MicroserviceFilterSupport
 import uk.gov.hmrc.play.filters.frontend.CookieCryptoFilter
@@ -34,6 +32,4 @@ object SessionCookieCryptoFilter extends CookieCryptoFilter with MicroserviceFil
 
   def decrypt(encryptedCookie: String): String = crypto.decrypt(Crypted(encryptedCookie)).value
 
-  implicit val system = ActorSystem()
-  override implicit def mat: Materializer = ActorMaterializer()
 }


### PR DESCRIPTION
Using a new ActorMaterializer instead of the Play app's Materializer seems to cause a memory leak in native-apps-api-orchestration (this can be reproduced by running the performance tests in ngc-performance-tests).

This class seems to have been copied from frontend-bootstrap, and before the Play 2.5 upgrade it did not override the Materializer. frontend-bootstrap's Play 2.5 version does not override the Materializer. This suggests the override is not necessary.